### PR TITLE
make browsersync HTTP by default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -339,27 +339,19 @@ gulp.task('publish', function () {
  * Process tasks and reload browsers on file changes.
  *
  * https://www.npmjs.com/package/browser-sync
- *
- * If you are not using a self-signed certificate, use the below config:
- *
- * browsersync( {
- *	    proxy: 'genesis-starter.dev',
- *	    notify: false,
- *	    open: false,
- * } );
  */
 gulp.task('watch', function () {
 
 	// HTTPS (optional).
 	browsersync({
-		proxy: 'https://genesis-starter.dev',
+		proxy: 'http://genesis-starter.dev',
 		port: 8000,
 		notify: false,
 		open: false,
-		https: {
-			"key": "/Users/seothemes/.valet/Certificates/genesis-starter.dev.key",
-			"cert": "/Users/seothemes/.valet/Certificates/genesis-starter.dev.crt"
-		}
+		// https: {
+		// 	"key": "/Users/seothemes/.valet/Certificates/genesis-starter.dev.key",
+		// 	"cert": "/Users/seothemes/.valet/Certificates/genesis-starter.dev.crt"
+		// }
 	});
 
 	// Run tasks when files change.


### PR DESCRIPTION
I now see the notes on the config to use if not using a self-signed cert but starting with HTTP by default will help get others setup using gulp quicker. 

If accepted then an update to the ["Using Browsersync" in the README](https://github.com/seothemes/genesis-starter#using-browsersync) will be needed.